### PR TITLE
fix: correct 'attribtue_name' to 'attribute_name' parameter typo (ability_system_component.gd:279)

### DIFF
--- a/GodotGAS/components/ability_system_component.gd
+++ b/GodotGAS/components/ability_system_component.gd
@@ -276,10 +276,10 @@ func get_attribute(attribute_name: String) -> AttributeData:
 
 
 ## Helper function to determine if a AttributeData resource exists.
-func has_attribute(attribtue_name: String) -> bool:
+func has_attribute(attribute_name: String) -> bool:
 	for set in attribute_sets:
-		if attribtue_name in set:
-			if set.get(attribtue_name) is AttributeData:
+		if attribute_name in set:
+			if set.get(attribute_name) is AttributeData:
 				return true
 	return false
 


### PR DESCRIPTION
## Summary
Corrects 'attribtue_name' to 'attribute_name' typo in the `has_attribute()` function parameter name.

## Fix
- GodotGAS/components/ability_system_component.gd:279: `func has_attribute(attribtue_name: String)` → `func has_attribute(attribute_name: String)`
- Lines 281-282: Updated parameter usage to match

## Testing
Verified the fix locally. No behavioral changes, only parameter name correction.

## Related
Fixes issue #7