### PR TITLE
Add new project settings for GodotGAS

### DIFF
--- a/GodotGAS/editor/dashboard_tabs/attribute_sets_tab.gd
+++ b/GodotGAS/editor/dashboard_tabs/attribute_sets_tab.gd
@@ -11,11 +11,8 @@
 @icon("res://addons/GodotGAS/icons/godot_gas_asc.svg")
 extends Control
 
-## The file path where attribute drafts are saved.
-const DRAFTS_PATH = "res://addons/GodotGAS/data/attribute_drafts.cfg"
-
-## The default directory for generated attribute scripts.
-const DEFAULT_OUTPUT_DIR = "res://gas_attributes"
+## Addon project settings.
+const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
 
 ## Icon for Attribute Set categories.
 const SET_ICON = preload("res://addons/GodotGAS/icons/godot_gas_attributes.svg")
@@ -43,9 +40,6 @@ var _drafts: ConfigFile = ConfigFile.new()
 
 ## The name of the currently selected Attribute Set.
 var _current_set: String = ""
-
-## The directory path where the generated script will be saved.
-var _output_dir: String = DEFAULT_OUTPUT_DIR
 
 ## The popup dialog used for configuring generation settings.
 var _settings_dialog: ConfirmationDialog
@@ -98,9 +92,6 @@ var _text_accent: Color
 ## Reference to the label displaying the currently selected set.
 @onready var _lbl_selected_set: Label = %LblSelectedSet
 
-## Reference to the settings button.
-@onready var _btn_settings: Button = %BtnSettings
-
 ## Reference to the tree node displaying attributes for the selected set.
 @onready var _attribute_tree: Tree = %AttributeTree
 
@@ -132,9 +123,7 @@ func _ready() -> void:
 
 ## Loads the saved draft data and settings.
 func _load_drafts() -> void:
-	if _drafts.load(DRAFTS_PATH) == OK:
-		# Load custom directory if it exists, otherwise use default
-		_output_dir = _drafts.get_value("Settings", "output_dir", DEFAULT_OUTPUT_DIR)
+	_drafts.load(GodotGasProjectSettings.get_attributes_draft_config_path())
 
 
 ## Binds all signals and constructs the dynamic dialogs.
@@ -143,7 +132,6 @@ func _setup_ui() -> void:
 	_btn_create_set.pressed.connect(_on_create_set_pressed)
 	_btn_add_attribute.pressed.connect(_on_add_attribute_pressed)
 	_btn_generate_script.pressed.connect(_on_generate_script_pressed)
-	_btn_settings.pressed.connect(_on_settings_pressed)
 	
 	_new_attribute_input.text_submitted.connect(func(_t): _on_add_attribute_pressed())
 	_new_set_input.text_submitted.connect(func(_t): _on_create_set_pressed())
@@ -212,62 +200,7 @@ func _setup_ui() -> void:
 	_error_dialog.title = "Action Failed"
 	add_child(_error_dialog)
 
-	# Build Settings Dialog
-	_btn_settings.icon = get_theme_icon("Tools", "EditorIcons")
-	
-	_settings_dialog = ConfirmationDialog.new()
-	_settings_dialog.title = "Attribute Set Settings"
-	_settings_dialog.confirmed.connect(_on_settings_saved)
-
-	var vbox = VBoxContainer.new()
-	var hbox = HBoxContainer.new()
-	
-	_dir_label = LineEdit.new()
-	_dir_label.editable = false
-	_dir_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	
-	var btn_browse = Button.new()
-	btn_browse.text = "Browse..."
-	btn_browse.pressed.connect(func(): _dir_dialog.popup_file_dialog())
-	btn_browse.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	
-	var btn_reset = Button.new()
-	btn_reset.text = "Reset Default"
-	btn_reset.pressed.connect(func(): _dir_label.text = DEFAULT_OUTPUT_DIR)
-	btn_reset.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	
-	hbox.add_child(btn_browse)
-	hbox.add_child(btn_reset)
-	var label = Label.new()
-	label.text = "Script Output Directory: "
-	vbox.add_child(label)
-	vbox.add_child(_dir_label)
-	vbox.add_child(hbox)
-	_settings_dialog.add_child(vbox)
-	add_child(_settings_dialog)
-	
-	_dir_dialog = EditorFileDialog.new()
-	_dir_dialog.file_mode = EditorFileDialog.FILE_MODE_OPEN_DIR
-	_dir_dialog.dir_selected.connect(func(dir): _dir_label.text = dir)
-	add_child(_dir_dialog)
-	
 	_update_right_panel_state()
-#endregion
-
-
-#region Settings Logic
-## Triggered when the settings icon is clicked.
-func _on_settings_pressed() -> void:
-	_dir_label.text = _output_dir
-	_settings_dialog.popup_centered(Vector2i(450, 0))
-
-
-## Triggered when the user confirms changes in the settings dialog.
-func _on_settings_saved() -> void:
-	_output_dir = _dir_label.text
-	_drafts.set_value("Settings", "output_dir", _output_dir)
-	_drafts.save(DRAFTS_PATH)
-	print("GodotGAS: Output directory updated to ", _output_dir)
 #endregion
 
 
@@ -320,7 +253,7 @@ func _on_set_tree_button_clicked(item: TreeItem, column: int, id: int, mouse_but
 				
 			_drafts.set_value(new_name, key, val)
 			
-		_drafts.save(DRAFTS_PATH)
+		_drafts.save(GodotGasProjectSettings.get_attributes_draft_config_path())
 		_refresh_set_tree()
 		
 	elif id == TreeBtn.DELETE:
@@ -356,7 +289,7 @@ func _on_set_tree_item_edited() -> void:
 	for key in _drafts.get_section_keys(old_name):
 		_drafts.set_value(new_name, key, _drafts.get_value(old_name, key))
 	_drafts.erase_section(old_name)
-	_drafts.save(DRAFTS_PATH)
+	_drafts.save(GodotGasProjectSettings.get_attributes_draft_config_path())
 	
 	item.set_metadata(0, new_name)
 	item.set_text(0, new_name) # Ensure pascal_case reflects
@@ -386,8 +319,8 @@ func _on_create_set_pressed() -> void:
 		return
 		
 	if not _drafts.has_section(set_name):
-		_drafts.set_value(set_name, "_initialized", true) 
-		_drafts.save(DRAFTS_PATH)
+		_drafts.set_value(set_name, "_initialized", true)
+		_drafts.save(GodotGasProjectSettings.get_attributes_draft_config_path())
 		_new_set_input.text = ""
 		_current_set = set_name
 		_refresh_set_tree()
@@ -482,7 +415,7 @@ func _on_attribute_tree_button_clicked(item: TreeItem, column: int, id: int, mou
 			data_dict = data_dict.duplicate(true)
 			
 		_drafts.set_value(_current_set, new_name, data_dict)
-		_drafts.save(DRAFTS_PATH)
+		_drafts.save(GodotGasProjectSettings.get_attributes_draft_config_path())
 		_refresh_attribute_tree()
 		
 	elif id == TreeBtn.DELETE:
@@ -509,7 +442,7 @@ func _on_icon_popup_id_pressed(id: int) -> void:
 		
 	data_dict["icon"] = chosen_icon_name
 	_drafts.set_value(_current_set, _editing_icon_attr, data_dict)
-	_drafts.save(DRAFTS_PATH)
+	_drafts.save(GodotGasProjectSettings.get_attributes_draft_config_path())
 	
 	_editing_icon_attr = "" # Clear state
 	_refresh_attribute_tree()
@@ -549,14 +482,14 @@ func _on_attribute_tree_item_edited() -> void:
 		_drafts.set_value(_current_set, new_name, data_dict)
 		item.set_metadata(0, new_name)
 		item.set_text(0, new_name) # Ensure snake_case reflects
-		_drafts.save(DRAFTS_PATH)
+		_drafts.save(GodotGasProjectSettings.get_attributes_draft_config_path())
 		
 	elif col == 1: # Changed the default value
 		var new_val = item.get_text(1).to_float()
 		item.set_text(1, str(new_val)) # Visually clean formatting
 		data_dict["value"] = new_val
 		_drafts.set_value(_current_set, old_name, data_dict)
-		_drafts.save(DRAFTS_PATH)
+		_drafts.save(GodotGasProjectSettings.get_attributes_draft_config_path())
 
 
 ## Triggered when adding a brand new attribute to the set.
@@ -578,7 +511,7 @@ func _on_add_attribute_pressed() -> void:
 	var data_dict = {"value": val, "icon": icon_name}
 	
 	_drafts.set_value(_current_set, attr_name, data_dict)
-	_drafts.save(DRAFTS_PATH)
+	_drafts.save(GodotGasProjectSettings.get_attributes_draft_config_path())
 	
 	_new_attribute_input.text = ""
 	_new_attribute_value.value = 0.0
@@ -593,13 +526,13 @@ func _execute_delete() -> void:
 		_drafts.erase_section(_delete_target_name)
 		if _current_set == _delete_target_name:
 			_current_set = ""
-		_drafts.save(DRAFTS_PATH)
+		_drafts.save(GodotGasProjectSettings.get_attributes_draft_config_path())
 		_refresh_set_tree()
 		_refresh_attribute_tree()
 		
 	elif _delete_target_type == "attribute":
 		_drafts.erase_section_key(_current_set, _delete_target_name)
-		_drafts.save(DRAFTS_PATH)
+		_drafts.save(GodotGasProjectSettings.get_attributes_draft_config_path())
 		_refresh_attribute_tree()
 		
 	_delete_target_type = ""
@@ -613,8 +546,9 @@ func _on_generate_script_pressed() -> void:
 	if _current_set == "": 
 		return
 	
+	var output_dir: = GodotGasProjectSettings.get_attributes_output_dir_path()
 	var file_name = _current_set.to_snake_case() + "_attribute_set.gd"
-	var file_path = _output_dir + "/" + file_name
+	var file_path = output_dir.path_join(file_name)
 	
 	# SAFEGUARD: Check if the script is open in the Editor
 	var script_editor = EditorInterface.get_script_editor()
@@ -628,8 +562,8 @@ func _on_generate_script_pressed() -> void:
 			return
 
 	# Ensure directory exists
-	if not DirAccess.dir_exists_absolute(_output_dir):
-		var err = DirAccess.make_dir_recursive_absolute(_output_dir)
+	if not DirAccess.dir_exists_absolute(output_dir):
+		var err = DirAccess.make_dir_recursive_absolute(output_dir)
 		if err != OK:
 			push_error("GodotGAS: Failed to create output directory. Error: ", err)
 			return

--- a/GodotGAS/editor/dashboard_tabs/cue_manager_tab.gd
+++ b/GodotGAS/editor/dashboard_tabs/cue_manager_tab.gd
@@ -11,11 +11,8 @@
 @icon("res://addons/GodotGAS/icons/godot_gas_asc.svg")
 extends Control
 
-## File path to the default cue registry resource.
-const REGISTRY_PATH = "res://addons/GodotGAS/data/default_cue_registry.tres"
-
-## File path to the default tag registry resource.
-const TAG_REGISTRY_PATH = "res://addons/GodotGAS/data/default_tag_registry.tres"
+## Addon project settings.
+const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
 
 ## Icon used to represent gameplay tags.
 const TAG_ICON = preload("res://addons/GodotGAS/icons/godot_gas_tags.svg")
@@ -100,10 +97,11 @@ func _ready() -> void:
 
 ## Loads the cue registry from disk.
 func _load_registry() -> void:
-	if ResourceLoader.exists(REGISTRY_PATH):
-		_registry = load(REGISTRY_PATH) as GameplayCueRegistry
+	var cue_registry_path: = GodotGasProjectSettings.get_registry_cue_path()
+	if ResourceLoader.exists(cue_registry_path):
+		_registry = load(cue_registry_path) as GameplayCueRegistry
 	else:
-		push_warning("GodotGAS: Cue Registry not found at " + REGISTRY_PATH)
+		push_warning("GodotGAS: Cue Registry not found at " + cue_registry_path)
 
 
 ## Wires up signals and instantiates the dynamic UI dialogs.
@@ -225,11 +223,12 @@ func _build_tag_tree(filter: String = "") -> void:
 	_tag_tree.clear()
 	var root = _tag_tree.create_item()
 	
-	if not ResourceLoader.exists(TAG_REGISTRY_PATH):
-		push_error("GodotGAS: Tag Registry not found at " + TAG_REGISTRY_PATH)
+	var tag_registry_path: = GodotGasProjectSettings.get_registry_tag_path()
+	if not ResourceLoader.exists(tag_registry_path):
+		push_error("GodotGAS: Tag Registry not found at " + tag_registry_path)
 		return
 		
-	var tag_registry = load(TAG_REGISTRY_PATH)
+	var tag_registry = load(tag_registry_path)
 	
 	# Create a list of currently mapped tags to grey them out
 	var taken_tags = []
@@ -316,7 +315,7 @@ func _on_add_mapping_pressed() -> void:
 		new_entry.scene = _draft_scene
 		_registry.entries.append(new_entry)
 		
-	ResourceSaver.save(_registry, REGISTRY_PATH)
+	ResourceSaver.save(_registry, GodotGasProjectSettings.get_registry_cue_path())
 	_reset_form()
 	
 	# Refresh using the current search bar text so the list doesn't visually reset
@@ -356,7 +355,7 @@ func _execute_delete() -> void:
 		return
 		
 	_registry.entries.remove_at(_delete_index)
-	ResourceSaver.save(_registry, REGISTRY_PATH)
+	ResourceSaver.save(_registry,  GodotGasProjectSettings.get_registry_cue_path())
 	
 	if _delete_index == _editing_index:
 		_reset_form()

--- a/GodotGAS/editor/dashboard_tabs/tag_manager_tab.gd
+++ b/GodotGAS/editor/dashboard_tabs/tag_manager_tab.gd
@@ -11,8 +11,8 @@
 @icon("res://addons/GodotGAS/icons/godot_gas_asc.svg")
 extends Control
 
-## File path to the default tag registry resource.
-const TAG_REGISTRY_PATH = "res://addons/GodotGAS/data/default_tag_registry.tres"
+## Addon project settings.
+const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
 
 ## Icon used to represent gameplay tags in the tree view.
 const TAG_ICON = preload("res://addons/GodotGAS/icons/godot_gas_tags.svg")
@@ -56,10 +56,12 @@ func _ready() -> void:
 
 ## Loads the tag registry from disk.
 func _load_registry() -> void:
-	if ResourceLoader.exists(TAG_REGISTRY_PATH):
-		_registry = load(TAG_REGISTRY_PATH) as GameplayTagRegistry
+	var tag_registry_path = GodotGasProjectSettings.get_registry_tag_path()
+	if ResourceLoader.exists(tag_registry_path):
+		_registry = load(tag_registry_path) as GameplayTagRegistry
 	else:
-		push_warning("GodotGAS: Tag Registry not found at " + TAG_REGISTRY_PATH)
+		if not Engine.is_editor_hint() or EditorInterface.is_plugin_enabled("GodotGAS"):
+			push_warning("GodotGAS: Tag Registry not found at " + tag_registry_path)
 
 
 ## Wires up signals and configures the initial UI state.

--- a/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd
+++ b/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd
@@ -11,8 +11,8 @@
 @icon("res://addons/GodotGAS/icons/godot_gas_asc.svg")
 extends EditorProperty
 
-## File path to the default tag registry resource.
-const REGISTRY_PATH = "res://addons/GodotGAS/data/default_tag_registry.tres"
+## Addon project settings.
+const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
 
 ## The main button displayed in the inspector row.
 var _button := Button.new()
@@ -47,7 +47,7 @@ var _is_updating_from_tree: bool = false
 
 #region Initialization & Lifecycle
 func _init() -> void:
-	_registry = load(REGISTRY_PATH) as GameplayTagRegistry
+	_registry = load(GodotGasProjectSettings.get_registry_tag_path()) as GameplayTagRegistry
 	
 	_button.text = "Edit Tags..."
 	_button.clip_text = true

--- a/GodotGAS/gameplay_tag/gameplay_tag_generator.gd
+++ b/GodotGAS/gameplay_tag/gameplay_tag_generator.gd
@@ -11,16 +11,17 @@
 @icon("res://addons/GodotGAS/icons/godot_gas_asc.svg")
 class_name GameplayTagGenerator extends RefCounted
 
-## The target file path where the generated tag constants script will be saved.
-const GENERATED_FILE_PATH = "res://addons/GodotGAS/data/gameplay_tags.gd"
+## Addon project settings.
+const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
 
 
 #region Code Generation
 ## Takes an array of tags and writes a static class file with constants for IDE autocomplete.
 static func generate_tags_file(tags: Array[StringName]) -> void:
-	var file = FileAccess.open(GENERATED_FILE_PATH, FileAccess.WRITE)
+	var generated_tag_script_path: = GodotGasProjectSettings.get_generated_tag_script_path()
+	var file = FileAccess.open(generated_tag_script_path, FileAccess.WRITE)
 	if not file:
-		printerr("GodotGAS: Failed to open path for tag generation: ", GENERATED_FILE_PATH)
+		printerr("GodotGAS: Failed to open path for tag generation: ", generated_tag_script_path)
 		return
 
 	# Write standard header warning so users don't manually edit it

--- a/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd
+++ b/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd
@@ -14,6 +14,9 @@ extends EditorInspectorPlugin
 ## The preloaded custom editor property script used for tag selection.
 const GameplayTagEditorProperty = preload("res://addons/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd")
 
+## Addon project settings.
+const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
+
 
 #region Inspector Parsing
 ## Native Godot virtual to determine if this plugin handles the current object.
@@ -24,8 +27,32 @@ func _can_handle(object: Object) -> bool:
 
 ## Native Godot virtual that intercepts property rendering to inject custom UI.
 func _parse_property(object: Object, type: Variant.Type, name: String, hint_type: PropertyHint, hint_string: String, usage_flags: int, wide: bool) -> bool:
-	# We intercept arrays or strings containing the word 'tag'
-	if "tag" in name.to_lower():
+	# Here, we check if the object in the inspector is literally a `GameplayTagRegistry`.
+	var is_native: = name.to_lower() == "tags" and object is GameplayTagRegistry
+	if not GodotGasProjectSettings.get_editor_tag_property_editor_enabled() or is_native:
+		# Make sure to return `false` when `is native` because we don't want the tag editor property
+		# to show up in the registries. People could start to click on tags to deactivate them,
+		# but it would instead delete them permanently.
+		return false
+	var matches_on: = GodotGasProjectSettings.get_editor_tag_property_editor_match_on()
+	var match_type: = GodotGasProjectSettings.get_editor_tag_property_editor_match_type()
+
+	# We intercept arrays or strings containing the needle.
+	# Here, we match 
+	var matched: = false
+	if not matched:
+		for match_on in matches_on:
+			match match_type:
+				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.PREFIX:
+					matched = name.to_lower().begins_with(match_on)
+				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.SUFFIX:
+					matched = name.to_lower().ends_with(match_on)
+				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.ANYWHERE:
+					matched = match_on in name.to_lower()
+			if matched:
+				break
+
+	if matched:
 		match type:
 			TYPE_ARRAY, \
 			TYPE_PACKED_STRING_ARRAY, \

--- a/GodotGAS/godot_gas_plugin.gd
+++ b/GodotGAS/godot_gas_plugin.gd
@@ -23,6 +23,9 @@ const DASHBOARD_SCENE = preload("res://addons/GodotGAS/editor/godot_gas_dashboar
 ## Preloaded script for the tag inspector plugin.
 const GameplayTagInspectorPlugin = preload("res://addons/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd")
 
+## Preloaded scripts for the plugin project settings.
+const GodotGasProjectSettings = preload("res://addons/GodotGAS/utilities/project_settings.gd")
+
 ## Reference to the active dashboard control node in the editor.
 var _dashboard_instance: Control
 
@@ -33,12 +36,14 @@ var _tag_inspector: EditorInspectorPlugin
 #region Plugin Lifecycle
 ## Called when the plugin is activated.
 func _enable_plugin() -> void:
-	# Auto-register the Singleton so the user doesn't have to
+ # Auto-register the Singleton so the user doesn't have to
 	add_autoload_singleton(CUE_MANAGER_NAME, CUE_MANAGER_PATH)
 
 
 ## Called when the plugin enters the editor tree.
 func _enter_tree() -> void:
+	GodotGasProjectSettings.init_project_settings()
+
 	_tag_inspector = GameplayTagInspectorPlugin.new()
 	add_inspector_plugin(_tag_inspector)
 	

--- a/GodotGAS/managers/gameplay_cue_manager.gd
+++ b/GodotGAS/managers/gameplay_cue_manager.gd
@@ -10,8 +10,8 @@
 @icon("res://addons/GodotGAS/icons/godot_gas_asc.svg")
 extends Node
 
-## File path to the default cue registry resource.
-const REGISTRY_PATH = "res://addons/GodotGAS/data/default_cue_registry.tres"
+## Addon project settings.
+const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
 
 ## Internal dictionary holding the object pool. Format: { "tag": [GameplayCueNotify, ...] }
 var _pool: Dictionary = {}
@@ -28,11 +28,13 @@ func _ready() -> void:
 
 ## Loads the cue registry from disk and prepares the object pool.
 func _load_registry() -> void:
-	if not ResourceLoader.exists(REGISTRY_PATH):
-		push_warning("GodotGAS: No cue registry found at " + REGISTRY_PATH)
+	var cue_registry_path: = GodotGasProjectSettings.get_registry_cue_path()
+	if not ResourceLoader.exists(cue_registry_path):
+		if not Engine.is_editor_hint() or EditorInterface.is_plugin_enabled("GodotGAS"):
+			push_warning("GodotGAS: No cue registry found at " + cue_registry_path)
 		return
 		
-	var registry = load(REGISTRY_PATH) as GameplayCueRegistry
+	var registry = load(cue_registry_path) as GameplayCueRegistry
 	if not registry:
 		return
 		

--- a/GodotGAS/utilities/project_settings.gd
+++ b/GodotGAS/utilities/project_settings.gd
@@ -1,0 +1,202 @@
+extends Object
+
+enum EditorTagsTagEditorPropertyMatchType {
+	PREFIX,
+	SUFFIX,
+	ANYWHERE,
+}
+
+const PROJECT_SETTINGS_NAME: = "godot_gas"
+const PROJECT_SETTINGS_NAME_EDITOR: = PROJECT_SETTINGS_NAME + "/editor"
+const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR: = PROJECT_SETTINGS_NAME_EDITOR + "/tag_property_editor"
+const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR + "/enable"
+const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR + "/match"
+const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH + "/on"
+const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH + "/type"
+const PROJECT_SETTINGS_NAME_RESOURCES: = PROJECT_SETTINGS_NAME + "/resources"
+const PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES: = PROJECT_SETTINGS_NAME_RESOURCES + "/attributes"
+const PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE: = PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES + "/draft_configuration_file"
+const PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_OUTPUT_DIR: = PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES + "/output_directory"
+const PROJECT_SETTINGS_NAME_RESOURCES_CUES: = PROJECT_SETTINGS_NAME_RESOURCES + "/cues"
+const PROJECT_SETTINGS_NAME_RESOURCES_CUES_REGISTRY: = PROJECT_SETTINGS_NAME_RESOURCES_CUES + "/registry_file"
+const PROJECT_SETTINGS_NAME_RESOURCES_TAGS: = PROJECT_SETTINGS_NAME_RESOURCES + "/tags"
+const PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY: = PROJECT_SETTINGS_NAME_RESOURCES_TAGS + "/registry_file"
+const PROJECT_SETTINGS_NAME_RESOURCES_TAGS_GENERATED_SCRIPT: = PROJECT_SETTINGS_NAME_RESOURCES_TAGS + "/generated_script"
+
+const PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE: = true
+const PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON: = "gas_tag,gas_tags"
+const PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE: = EditorTagsTagEditorPropertyMatchType.SUFFIX
+
+const PROJECT_SETTINGS_DEFAULT_PATH: = "res://godot_gas"
+const PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE: = PROJECT_SETTINGS_DEFAULT_PATH + "/attributes_draft.cfg"
+const PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_ATTRIBUTES_OUTPUT_DIR: = PROJECT_SETTINGS_DEFAULT_PATH + "/attributes"
+const PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_CUES_REGISTRY: = PROJECT_SETTINGS_DEFAULT_PATH + "/cue_registry.tres"
+const PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_TAGS_REGISTRY: = PROJECT_SETTINGS_DEFAULT_PATH + "/tag_registry.tres"
+const PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_TAGS_GENERATED_SCRIPT: = PROJECT_SETTINGS_DEFAULT_PATH + "/gameplay_tags.gd"
+
+
+static func init_project_settings() -> void:
+	_init_project_settings_attributes_draft_config_path()
+	_init_project_settings_attributes_output_dir()
+	_init_project_settings_generated_tag_script_path()
+	_init_project_settings_registry_cue()
+	_init_project_settings_registry_tag()
+	_init_project_settings_editor_tag_property_editor()
+
+
+static func get_attributes_draft_config_path() -> String:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE)
+	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE)
+
+
+static func get_attributes_output_dir_path() -> String:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_OUTPUT_DIR):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_OUTPUT_DIR, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_ATTRIBUTES_OUTPUT_DIR)
+	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_OUTPUT_DIR)
+
+
+static func get_generated_tag_script_path() -> String:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_GENERATED_SCRIPT):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_GENERATED_SCRIPT, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_TAGS_GENERATED_SCRIPT)
+	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_GENERATED_SCRIPT)
+
+
+static func get_registry_cue_path() -> String:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_CUES_REGISTRY):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_CUES_REGISTRY, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_CUES_REGISTRY)
+	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_RESOURCES_CUES_REGISTRY)
+
+
+static func get_registry_tag_path() -> String:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_TAGS_REGISTRY)
+	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY)
+
+
+static func get_editor_tag_property_editor_enabled() -> bool:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
+	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
+
+
+static func get_editor_tag_property_editor_match_on() -> PackedStringArray:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON)
+	var match_on_list: = ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON) as String
+	return match_on_list.split(",", false)
+
+
+static func get_editor_tag_property_editor_match_type() -> EditorTagsTagEditorPropertyMatchType:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
+	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
+
+
+static func _init_project_settings_attributes_output_dir() -> void:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_OUTPUT_DIR):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_OUTPUT_DIR, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_ATTRIBUTES_OUTPUT_DIR)
+	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_OUTPUT_DIR, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_ATTRIBUTES_OUTPUT_DIR)
+	ProjectSettings.add_property_info({
+		"name": PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_OUTPUT_DIR,
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_DIR,
+	})
+	var output_dir: String = ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_OUTPUT_DIR)
+	if not DirAccess.dir_exists_absolute(output_dir):
+		DirAccess.make_dir_recursive_absolute(output_dir)
+
+
+static func _init_project_settings_attributes_draft_config_path() -> void:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE)
+	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE)
+	ProjectSettings.add_property_info({
+		"name": PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE,
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_FILE_PATH,
+	})
+
+
+static func _init_project_settings_generated_tag_script_path() -> void:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_GENERATED_SCRIPT):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_GENERATED_SCRIPT, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_TAGS_GENERATED_SCRIPT)
+	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_GENERATED_SCRIPT, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_TAGS_GENERATED_SCRIPT)
+	ProjectSettings.add_property_info({
+		"name": PROJECT_SETTINGS_NAME_RESOURCES_TAGS_GENERATED_SCRIPT,
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_FILE_PATH,
+	})
+
+
+static func _init_project_settings_registry_cue() -> void:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_CUES_REGISTRY):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_CUES_REGISTRY, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_CUES_REGISTRY)
+	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_RESOURCES_CUES_REGISTRY, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_CUES_REGISTRY)
+	ProjectSettings.add_property_info({
+		"name": PROJECT_SETTINGS_NAME_RESOURCES_CUES_REGISTRY,
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_FILE_PATH,
+	})
+	var registry_path: String = ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_RESOURCES_CUES_REGISTRY)
+	if not FileAccess.file_exists(registry_path):
+		var default_registry = GameplayCueRegistry.new()
+		DirAccess.make_dir_recursive_absolute(registry_path.get_base_dir())
+		ResourceSaver.save(default_registry, registry_path)
+
+
+static func _init_project_settings_registry_tag() -> void:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_TAGS_REGISTRY)
+	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_TAGS_REGISTRY)
+	ProjectSettings.add_property_info({
+		"name": PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY,
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_FILE_PATH,
+	})
+	var registry_path: String = ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY)
+	if not FileAccess.file_exists(registry_path):
+		var default_registry = GameplayTagRegistry.new()
+		default_registry.add_tag(&"Example.Ability.Arrow.Impact")
+		default_registry.add_tag(&"Example.Ability.Arrow.Shoot")
+		default_registry.add_tag(&"Example.Ability.Heal.Triggered")
+		default_registry.add_tag(&"Example.Ability.Poison.Applied")
+		default_registry.add_tag(&"Example.Ability.Poison.Cast")
+		default_registry.add_tag(&"Example.Event.Damage.Critical")
+		default_registry.add_tag(&"Example.Event.Damage.Missed")
+		default_registry.add_tag(&"Example.Event.Damage.Normal")
+		default_registry.add_tag(&"Example.Event.Defend.Hit")
+		default_registry.add_tag(&"Example.State.Cooldown.Arrow")
+		default_registry.add_tag(&"Example.State.Cooldown.Poison")
+
+		DirAccess.make_dir_recursive_absolute(registry_path.get_base_dir())
+		ResourceSaver.save(default_registry, registry_path)
+
+
+static func _init_project_settings_editor_tag_property_editor() -> void:
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON)
+	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE):
+		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
+
+	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
+	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON)
+	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
+
+	ProjectSettings.add_property_info({
+		"name": PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE,
+		"type": TYPE_BOOL,
+	})
+	ProjectSettings.add_property_info({
+		"name": PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON,
+		"type": TYPE_STRING,
+	})
+	ProjectSettings.add_property_info({
+		"name": PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE,
+		"type": TYPE_INT,
+		"hint": PROPERTY_HINT_ENUM,
+		"hint_string": "Prefix,Suffix,Anywhere",
+	})
+


### PR DESCRIPTION
>[!WARNING]
>This includes breaking changes. Users should do the following in order to keep compatibility with the new project settings defaults.
>
>It is technically possible to adjust the project settings in order to match the current way of doing, but it isn't recommended.
>
>#### Files to move
> | From | To |
> | :--- | :--- |
> | `res://addons/GodotGAS/data/attribute_drafts.cfg` | `res://godot_gas/attribute_drafts.cfg` |
> | `res://addons/GodotGAS/data/default_cue_registry.tres` | `res://godot_gas/cue_registry.tres` |
> | `res://addons/GodotGAS/data/default_tag_registry.tres` | `res://godot_gas/tag_registry.tres` |
> | `res://addons/GodotGAS/data/gameplay_tags.gd` | `res://godot_gas/gameplay_tags.gd` |
> | `res://gas_attributes` | `res://godot_gas/attributes` |
>
>#### Directories to move
> | From | To |
> | :--- | :--- |
> | `res://gas_attributes` | `res://godot_gas/attributes` |

- Add `godot_gas/resources/attributes/output_directory` project setting
  - This is the output directory of the generated attributes.
  - Defaults to `res://godot_gas/attributes`.
- Add `godot_gas/resources/attributes/draft_configuration_file` project setting
  - This is the draft configuration file path.
  - Defaults to `res://godot_gas/attributes_draft.cfg`.
- Add `godot_gas/resources/cues/registry_file` project setting
  - This is the path of the cue registry file.
  - Defaults to `res://godot_gas/cue_registry.tres`.
- Add `godot_gas/resources/tags/registry_file` project setting
  - This is the path of the tag registry file.
  - Defaults to `res://godot_gas/tag_registry.tres`.
- Add `godot_gas/resources/tags/generated_script` project setting
  - This is the path of the generated tag script.
  - Defaults to `res://godot_gas/gameplay_tags.gd`.
- Add `godot_gas/editor/tag_editor_property/enable` project setting
  - This toggles the tag editor property.
  - Defaults to `true`.
- Add `godot_gas/editor/tag_editor_property/match/on` project setting
  - This `String` contains all the elements in a property name to match to
    toggle the tag editor property. That list is separated by commas.
  - Defaults to `"gas_tag,gas_tags"`.
- Add `godot_gas/editor/tag_editor_property/match/type` project setting
  - This enum is either "Prefix", "Suffix", or "Anywhere",
    shows the addon tag editor property only if the property name match is found
    following the match type.
  - Defaults to "Suffix".

### Screenshots
| FileSystem panel | New project settings (resources) | New project settings (editor) |
| :---: | :---: | :---: |
| <img width="292" height="384" alt="Capture d’écran, le 2026-07-28 à 17 04 40" src="https://github.com/user-attachments/assets/49a79b12-44ed-45c1-9fbb-1b6e4a65d8ed" /> | <img width="1213" height="747" alt="Capture d’écran, le 2026-07-29 à 16 11 55" src="https://github.com/user-attachments/assets/ec0f5a7f-bff8-4f61-ae2d-6ae4f3f7abda" /> | <img width="1214" height="749" alt="Capture d’écran, le 2026-07-29 à 16 38 28" src="https://github.com/user-attachments/assets/f9ae9774-4192-42e3-8cd3-0caa38534013" /> |