### PR TITLE
Add generated `.uid` files to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Godot-specific ignores
 .godot/
-*.uid
 exported_presets.cfg
 
 # Godot export silently creates these

--- a/GodotGAS/abilities/gameplay_ability.gd.uid
+++ b/GodotGAS/abilities/gameplay_ability.gd.uid
@@ -1,0 +1,1 @@
+uid://bejq8p46edc1q

--- a/GodotGAS/attributes/attribute_data.gd.uid
+++ b/GodotGAS/attributes/attribute_data.gd.uid
@@ -1,0 +1,1 @@
+uid://dapo84yjxq6qh

--- a/GodotGAS/attributes/attribute_set.gd.uid
+++ b/GodotGAS/attributes/attribute_set.gd.uid
@@ -1,0 +1,1 @@
+uid://bhr4dsrpc4jw8

--- a/GodotGAS/components/ability_system_component.gd.uid
+++ b/GodotGAS/components/ability_system_component.gd.uid
@@ -1,0 +1,1 @@
+uid://cbrvrpcenj2cn

--- a/GodotGAS/cues/gameplay_cue_entry.gd.uid
+++ b/GodotGAS/cues/gameplay_cue_entry.gd.uid
@@ -1,0 +1,1 @@
+uid://c31mycy3sv3aq

--- a/GodotGAS/cues/gameplay_cue_notify.gd.uid
+++ b/GodotGAS/cues/gameplay_cue_notify.gd.uid
@@ -1,0 +1,1 @@
+uid://cp2qiyupu4wkp

--- a/GodotGAS/cues/gameplay_cue_registry.gd.uid
+++ b/GodotGAS/cues/gameplay_cue_registry.gd.uid
@@ -1,0 +1,1 @@
+uid://dkt21eabd45kx

--- a/GodotGAS/editor/dashboard_tabs/attribute_sets_tab.gd.uid
+++ b/GodotGAS/editor/dashboard_tabs/attribute_sets_tab.gd.uid
@@ -1,0 +1,1 @@
+uid://bs7kyvq8kwqx1

--- a/GodotGAS/editor/dashboard_tabs/cue_manager_tab.gd.uid
+++ b/GodotGAS/editor/dashboard_tabs/cue_manager_tab.gd.uid
@@ -1,0 +1,1 @@
+uid://3gy87g7uedio

--- a/GodotGAS/editor/dashboard_tabs/tag_manager_tab.gd.uid
+++ b/GodotGAS/editor/dashboard_tabs/tag_manager_tab.gd.uid
@@ -1,0 +1,1 @@
+uid://dmjb21w3fa2fc

--- a/GodotGAS/effects/active_gameplay_effect.gd.uid
+++ b/GodotGAS/effects/active_gameplay_effect.gd.uid
@@ -1,0 +1,1 @@
+uid://cdacipvloa5xv

--- a/GodotGAS/effects/gameplay_effect.gd.uid
+++ b/GodotGAS/effects/gameplay_effect.gd.uid
@@ -1,0 +1,1 @@
+uid://c81papidngxvg

--- a/GodotGAS/effects/gameplay_effect_modifier.gd.uid
+++ b/GodotGAS/effects/gameplay_effect_modifier.gd.uid
@@ -1,0 +1,1 @@
+uid://bcow77l0bnh0s

--- a/GodotGAS/effects/gameplay_effect_spec.gd.uid
+++ b/GodotGAS/effects/gameplay_effect_spec.gd.uid
@@ -1,0 +1,1 @@
+uid://bn4u4lxae2eml

--- a/GodotGAS/effects/gameplay_execution_calculation.gd.uid
+++ b/GodotGAS/effects/gameplay_execution_calculation.gd.uid
@@ -1,0 +1,1 @@
+uid://b7ovihaaijli7

--- a/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd.uid
+++ b/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd.uid
@@ -1,0 +1,1 @@
+uid://ha6mfybd6fhi

--- a/GodotGAS/gameplay_tag/gameplay_tag_generator.gd.uid
+++ b/GodotGAS/gameplay_tag/gameplay_tag_generator.gd.uid
@@ -1,0 +1,1 @@
+uid://yiqh4yftc5is

--- a/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd.uid
+++ b/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://bgiqetu8igmtm

--- a/GodotGAS/gameplay_tag/gameplay_tag_registry.gd.uid
+++ b/GodotGAS/gameplay_tag/gameplay_tag_registry.gd.uid
@@ -1,0 +1,1 @@
+uid://cbna3i315ffo1

--- a/GodotGAS/godot_gas_plugin.gd.uid
+++ b/GodotGAS/godot_gas_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://8nxqsnuh1hr5

--- a/GodotGAS/managers/gameplay_cue_manager.gd.uid
+++ b/GodotGAS/managers/gameplay_cue_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://bh6ixabs0w700

--- a/GodotGAS/target_data/gameplay_ability_target_data.gd.uid
+++ b/GodotGAS/target_data/gameplay_ability_target_data.gd.uid
@@ -1,0 +1,1 @@
+uid://c8mqdqr0oojkk

--- a/GodotGAS/target_data/gameplay_effect_context.gd.uid
+++ b/GodotGAS/target_data/gameplay_effect_context.gd.uid
@@ -1,0 +1,1 @@
+uid://bkfoocfgh1gdv

--- a/GodotGAS/utilities/project_settings.gd.uid
+++ b/GodotGAS/utilities/project_settings.gd.uid
@@ -1,0 +1,1 @@
+uid://c7w4dgy6upgcd


### PR DESCRIPTION
This PR adds generated `.uid` files for the addon scripts.

It prevents similar errors of the following when updating GodotGAS in a project:

```
  WARNING: ./scene/resources/resource_format_text.cpp:501 - res://addons/GodotGAS/editor/godot_gas_dashboard.tscn:4 - ext_resource, invalid UID: uid://3gy87g7uedio - using text path instead: res://addons/GodotGAS/editor/dashboard_tabs/cue_manager_tab.gd
  WARNING: ./scene/resources/resource_format_text.cpp:501 - res://addons/GodotGAS/editor/godot_gas_dashboard.tscn:5 - ext_resource, invalid UID: uid://dmjb21w3fa2fc - using text path instead: res://addons/GodotGAS/editor/dashboard_tabs/tag_manager_tab.gd
  WARNING: ./scene/resources/resource_format_text.cpp:501 - res://addons/GodotGAS/editor/godot_gas_dashboard.tscn:7 - ext_resource, invalid UID: uid://bs7kyvq8kwqx1 - using text path instead: res://addons/GodotGAS/editor/dashboard_tabs/attribute_sets_tab.gd
  WARNING: ./scene/resources/resource_format_text.cpp:501 - res://godot_gas/tag_registry.tres:3 - ext_resource, invalid UID: uid://srsihfnklhd - using text path instead: res://addons/GodotGAS/gameplay_tag/gameplay_tag_registry.gd
  WARNING: ./scene/resources/resource_format_text.cpp:501 - res://godot_gas/cue_registry.tres:3 - ext_resource, invalid UID: uid://dgrvvvxdl46d1 - using text path instead: res://addons/GodotGAS/cues/gameplay_cue_entry.gd
  WARNING: ./scene/resources/resource_format_text.cpp:501 - res://godot_gas/cue_registry.tres:4 - ext_resource, invalid UID: uid://c4l0sbxnvse8t - using text path instead: res://addons/GodotGAS/cues/gameplay_cue_registry.gd

```

For more info, read the following excerpt from [the Godot UID introduction blog post](https://godotengine.org/article/uid-changes-coming-to-godot-4-4/#what-should-i-change-in-my-project-or-workflow):

>### What should I change in my project or workflow?
>
>The most important step is to **make sure `.uid` files are committed to version control**. In other words, `*.uid` should **not** be added to `.gitignore`.
>
>Secondly, when you move a script or shader outside Godot, **you should also move the `.uid` file along with it.** When you remove a script or shader outside Godot, you should also remove the `.uid` file, although this is less important – not removing the `.uid` file won’t break anything.