### PR TITLE
Add details for tag editor property

### DIFF
--- a/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd
+++ b/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd
@@ -14,6 +14,9 @@ extends EditorProperty
 ## Addon project settings.
 const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
 
+## Property type.
+var property_type: = TYPE_STRING
+
 ## The main button displayed in the inspector row.
 var _button := Button.new()
 
@@ -46,7 +49,16 @@ var _is_updating_from_tree: bool = false
 
 
 #region Initialization & Lifecycle
-func _init() -> void:
+func _init(type: = TYPE_STRING) -> void:
+	assert(
+		type == TYPE_ARRAY
+		or type == TYPE_PACKED_STRING_ARRAY
+		or type == TYPE_STRING
+		or type == TYPE_STRING_NAME,
+		"Unsupported variant type.",
+	)
+	self.property_type = property_type
+
 	_registry = load(GodotGasProjectSettings.get_registry_tag_path()) as GameplayTagRegistry
 	
 	_button.text = "Edit Tags..."
@@ -107,7 +119,7 @@ func _on_registry_changed() -> void:
 			
 	# If this specific inspector row lost a tag, update its text instantly
 	if did_change:
-		_button.text = "Tags (%d selected)" % _current_tags.size()
+		_update_button_text()
 
 
 ## Synchronizes the UI with the inspected object's data.
@@ -119,10 +131,46 @@ func _update_property() -> void:
 	elif val is StringName or val is String:
 		_current_tags = [val] if not String(val).is_empty() else []
 	
-	_button.text = "Tags (%d selected)" % _current_tags.size()
+	_update_button_text()
 	
 	if is_instance_valid(_popup) and _popup.visible and not _is_updating_from_tree:
 		_refresh_tree()
+
+
+func _update_button_text() -> void:
+	var tooltip_text: = ""
+	var current_tags: = _current_tags.duplicate()
+	current_tags.sort_custom(
+		func(a: String, b: String):
+			return a.casecmp_to(b) < 0
+	)
+
+	match property_type:
+		TYPE_STRING, \
+		TYPE_STRING_NAME:
+			if _current_tags.is_empty():
+				_button.text = "No tag"
+				tooltip_text = "No tag selected."
+			else:
+				_button.text = current_tags[0]
+				tooltip_text = "Selected tag:"
+				tooltip_text += "\n  - %s" % current_tags[0]
+		TYPE_ARRAY, \
+		TYPE_PACKED_STRING_ARRAY:
+			if _current_tags.is_empty():
+				_button.text = "No tags"
+				tooltip_text = "No tags selected."
+			else:
+				_button.text = "Tags (%d selected)" % current_tags.size()
+				var plural: = ""
+				if _current_tags.size() >= 2:
+					plural = "s"
+				tooltip_text = "Selected tag%s:" % plural
+				for current_tag in current_tags:
+					tooltip_text += "\n  - %s" % current_tag
+
+	_button.tooltip_text = tooltip_text
+
 #endregion
 
 
@@ -290,7 +338,7 @@ func _on_tree_button_clicked(item: TreeItem, column: int, id: int, mouse_button_
 		_current_tags.clear()
 		emit_changed(get_edited_property(), StringName(""))
 	
-	_button.text = "Tags (%d selected)" % _current_tags.size()
+	_update_button_text()
 	
 	_registry.remove_tag(tag_to_remove)
 	_set_status("Deleted tag: " + tag_to_remove, true)

--- a/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd
+++ b/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd
@@ -27,40 +27,67 @@ func _can_handle(object: Object) -> bool:
 
 ## Native Godot virtual that intercepts property rendering to inject custom UI.
 func _parse_property(object: Object, type: Variant.Type, name: String, hint_type: PropertyHint, hint_string: String, usage_flags: int, wide: bool) -> bool:
-	# Here, we check if the object in the inspector is literally a `GameplayTagRegistry`.
-	var is_native: = name.to_lower() == "tags" and object is GameplayTagRegistry
-	if not GodotGasProjectSettings.get_editor_tag_property_editor_enabled() or is_native:
-		# Make sure to return `false` when `is native` because we don't want the tag editor property
-		# to show up in the registries. People could start to click on tags to deactivate them,
-		# but it would instead delete them permanently.
+	var enable_editor_property: = false
+	var name_lowered: = name.to_lower()
+	var is_tag_property: = \
+		(object is GameplayCueEntry and name == "tag") \
+		or (object is GameplayAbility and ( \
+			name == "ability_tag" \
+			or name == "activation_blocked_tags" \
+			or name == "activation_required_tags" \
+			or name == "shared_cooldown_tags" \
+			or name == "trigger_event_tag" \
+		)) \
+		or (object is GameplayEffect and ( \
+			name == "application_required_tags" \
+			or name == "application_ignore_tags" \
+			or name == "application_cue_tags" \
+			or name == "periodic_cue_tags" \
+			or name == "granted_tags" \
+			or name == "event_tags" \
+		)) \
+		or (object is GameplayEffectSpec and name == "dynamic_tags")
+	var is_registry: =  \
+		(object is GameplayTagRegistry and name == "tags")
+
+	if not GodotGasProjectSettings.get_editor_tag_property_editor_enabled() or is_registry:
+		# Make sure to return `false` when `is_registry` because we don't want the tag editor
+        # property to show up in the registries. People could start to click on tags to deactivate
+        # them, but it would instead delete them permanently.
 		return false
-	var matches_on: = GodotGasProjectSettings.get_editor_tag_property_editor_match_on()
-	var match_type: = GodotGasProjectSettings.get_editor_tag_property_editor_match_type()
+	elif is_tag_property:
+		enable_editor_property = true
+	else:
+		var matches_on: = GodotGasProjectSettings.get_editor_tag_property_editor_match_on()
+		var match_type: = GodotGasProjectSettings.get_editor_tag_property_editor_match_type()
 
-	# We intercept arrays or strings containing the needle.
-	# Here, we match 
-	var matched: = false
-	if not matched:
-		for match_on in matches_on:
-			match match_type:
-				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.PREFIX:
-					matched = name.to_lower().begins_with(match_on)
-				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.SUFFIX:
-					matched = name.to_lower().ends_with(match_on)
-				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.ANYWHERE:
-					matched = match_on in name.to_lower()
-			if matched:
-				break
+		# We intercept arrays or strings containing the needle.
+		# Here, we match 
+		var matched: = false
+		if not matched:
+			for match_on in matches_on:
+				match match_type:
+					GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.PREFIX:
+						matched = name_lowered.begins_with(match_on)
+					GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.SUFFIX:
+						matched = name_lowered.ends_with(match_on)
+					GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.ANYWHERE:
+						matched = match_on in name_lowered
+				if matched:
+					break
 
-	if matched:
-		match type:
-			TYPE_ARRAY, \
-			TYPE_PACKED_STRING_ARRAY, \
-			TYPE_STRING, \
-			TYPE_STRING_NAME:
-				var editor_property = GameplayTagEditorProperty.new()
-				add_property_editor(name, editor_property)
-				return true # Tells Godot to skip rendering the default input field
+		if matched:
+			match type:
+				TYPE_ARRAY, \
+				TYPE_PACKED_STRING_ARRAY, \
+				TYPE_STRING, \
+				TYPE_STRING_NAME:
+					enable_editor_property = true
 			
+	if enable_editor_property:
+		var editor_property = GameplayTagEditorProperty.new(type)
+		add_property_editor(name, editor_property)
+		return true # Tells Godot to skip rendering the default input field
+
 	return false
 #endregion


### PR DESCRIPTION
>[!NOTE]
>This PR also adds back tag editor property on native addon classes (regression from #10, they were showing as standard properties due to their name not being "tags").

This PR adds more details for the tag editor property:
- Change the text of buttons depending on the content and property type. 
- Added detailed tooltips 

| Description | Screenshot |
| :---: | :---: |
| No tag selected | <img width="358" height="240" alt="Capture d’écran, le 2026-08-07 à 18 02 45" src="https://github.com/user-attachments/assets/9ad2ff6f-4272-4b24-8d49-f95330859a6c" /> |
| [Single] Tag selected | <img width="330" height="325" alt="Capture d’écran, le 2026-08-07 à 18 05 46" src="https://github.com/user-attachments/assets/fcdd3fc6-99d5-4454-aa10-e5378935064a" /> |
| [Many] Tags selected | <img width="448" height="398" alt="Capture d’écran, le 2026-08-07 à 18 02 26" src="https://github.com/user-attachments/assets/17a03883-eaeb-4f79-90eb-5594de442959" /> |