### PR TITLE
Refactor tag property editor declaration

### DIFF
--- a/GodotGAS/abilities/gameplay_ability.gd
+++ b/GodotGAS/abilities/gameplay_ability.gd
@@ -19,13 +19,13 @@ signal ability_ended(was_cancelled: bool)
 ## The simple name to be used for logging or UI
 @export var ability_name: String = ""
 ## The tag that uniquely identifies this ability.
-@export var ability_tag: StringName = "Ability.None"
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var ability_tag: StringName = "Ability.None"
 ## The current level of this ability, used for scaling math and effects.
 @export var ability_level: float = 1.0
 ## Tags that, if present on the ASC, will prevent this ability from activating.
-@export var activation_blocked_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var activation_blocked_tags: Array[StringName] = []
 ## Tags that, if not present on the ASC, will prevent this ability from activating.
-@export var activation_required_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var activation_required_tags: Array[StringName] = []
 
 @export_category("Ability Mechanics")
 ## The gameplay effect applied to the owner to deduct resources upon committing.
@@ -35,11 +35,11 @@ signal ability_ended(was_cancelled: bool)
 ## Any additional shared effects (like a Global Cooldown) that should be applied when cast.
 @export var shared_cooldown_effects: Array[GameplayEffect] = []
 ## Explicitly list any shared cooldowns (like GCDs) this ability should respect.
-@export var shared_cooldown_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var shared_cooldown_tags: Array[StringName] = []
 
 @export_category("Ability Triggers")
 ## If set, the ASC will automatically try to activate this ability when it receives this exact event tag.
-@export var trigger_event_tag: StringName = ""
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var trigger_event_tag: StringName = ""
 
 @export_category("Input Routing")
 ## The integer ID this ability is currently bound to. -1 means unbound.

--- a/GodotGAS/cues/gameplay_cue_entry.gd
+++ b/GodotGAS/cues/gameplay_cue_entry.gd
@@ -13,7 +13,7 @@ class_name GameplayCueEntry extends Resource
 
 ## The gameplay tag associated with this cue. 
 ## Note: The GameplayTag inspector plugin automatically detects the variable name "tag".
-@export var tag: StringName
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var tag: StringName
 
 ## The PackedScene containing the visual or audio effects to trigger.
 @export var scene: PackedScene

--- a/GodotGAS/effects/gameplay_effect.gd
+++ b/GodotGAS/effects/gameplay_effect.gd
@@ -47,16 +47,16 @@ enum StackingPolicy {
 @export_category("Application Requirements")
 ## The target MUST have all of these tags for this effect to apply.
 ## (e.g., Must have 'Status.Burning' for an 'Explode' effect to work).
-@export var application_required_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var application_required_tags: Array[StringName] = []
 ## The target must NOT have any of these tags. If they do, the effect is blocked.
 ## (e.g., Target has 'Status.Immune.Poison', so block poison effects).
-@export var application_ignore_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var application_ignore_tags: Array[StringName] = []
 
 @export_category("Cue Management")
 ## Cues that play exactly once when the effect is first applied to a target.
-@export var application_cue_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var application_cue_tags: Array[StringName] = []
 ## Cues that play every time a periodic tick occurs.
-@export var periodic_cue_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var periodic_cue_tags: Array[StringName] = []
 
 @export_category("Attribute Modifiers")
 ## Custom mathematical scripts that run complex logic (e.g., Damage = Attack - Defense).
@@ -68,9 +68,9 @@ enum StackingPolicy {
 ## Tags granted to the target ASC for as long as this effect is active.
 ## Not used for events, but state ie: 'Status.Stunned'
 ## NOTE: Instant effects do not grant tags.
-@export var granted_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var granted_tags: Array[StringName] = []
 
 @export_category("Event Management")
 ## Tags broadcasted directly to the target's ASC as Gameplay Events upon application (or periodic tick).
 ## Ideal for waking up reactive passive abilities (e.g., 'Event.Damage.Taken').
-@export var event_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var event_tags: Array[StringName] = []

--- a/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd
+++ b/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd
@@ -14,9 +14,9 @@ extends EditorInspectorPlugin
 ## The preloaded custom editor property script used for tag selection.
 const GameplayTagEditorProperty = preload("res://addons/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd")
 
-## Addon project settings.
-const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
-
+const HINT_STRING_DELIMITER: = ","
+const HINT_STRING_GAS_PREFIX: = "gas::"
+const HINT_STRING_GAS_TAG_PREFIX: = "gas::tag"
 
 #region Inspector Parsing
 ## Native Godot virtual to determine if this plugin handles the current object.
@@ -27,30 +27,11 @@ func _can_handle(object: Object) -> bool:
 
 ## Native Godot virtual that intercepts property rendering to inject custom UI.
 func _parse_property(object: Object, type: Variant.Type, name: String, hint_type: PropertyHint, hint_string: String, usage_flags: int, wide: bool) -> bool:
-	# Here, we check if the object in the inspector is literally a `GameplayTagRegistry`.
-	var is_native: = name.to_lower() == "tags" and object is GameplayTagRegistry
-	if not GodotGasProjectSettings.get_editor_tag_property_editor_enabled() or is_native:
-		# Make sure to return `false` when `is native` because we don't want the tag editor property
-		# to show up in the registries. People could start to click on tags to deactivate them,
-		# but it would instead delete them permanently.
+	if hint_type != PROPERTY_HINT_NONE:
 		return false
-	var matches_on: = GodotGasProjectSettings.get_editor_tag_property_editor_match_on()
-	var match_type: = GodotGasProjectSettings.get_editor_tag_property_editor_match_type()
 
-	# We intercept arrays or strings containing the needle.
-	# Here, we match 
-	var matched: = false
-	if not matched:
-		for match_on in matches_on:
-			match match_type:
-				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.PREFIX:
-					matched = name.to_lower().begins_with(match_on)
-				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.SUFFIX:
-					matched = name.to_lower().ends_with(match_on)
-				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.ANYWHERE:
-					matched = match_on in name.to_lower()
-			if matched:
-				break
+	var hint_string_args: = hint_string.split(HINT_STRING_DELIMITER)
+	var matched: = HINT_STRING_GAS_TAG_PREFIX in hint_string_args
 
 	if matched:
 		match type:

--- a/GodotGAS/utilities/project_settings.gd
+++ b/GodotGAS/utilities/project_settings.gd
@@ -7,12 +7,6 @@ enum EditorTagsTagEditorPropertyMatchType {
 }
 
 const PROJECT_SETTINGS_NAME: = "godot_gas"
-const PROJECT_SETTINGS_NAME_EDITOR: = PROJECT_SETTINGS_NAME + "/editor"
-const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR: = PROJECT_SETTINGS_NAME_EDITOR + "/tag_property_editor"
-const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR + "/enable"
-const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR + "/match"
-const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH + "/on"
-const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH + "/type"
 const PROJECT_SETTINGS_NAME_RESOURCES: = PROJECT_SETTINGS_NAME + "/resources"
 const PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES: = PROJECT_SETTINGS_NAME_RESOURCES + "/attributes"
 const PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE: = PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES + "/draft_configuration_file"
@@ -22,10 +16,6 @@ const PROJECT_SETTINGS_NAME_RESOURCES_CUES_REGISTRY: = PROJECT_SETTINGS_NAME_RES
 const PROJECT_SETTINGS_NAME_RESOURCES_TAGS: = PROJECT_SETTINGS_NAME_RESOURCES + "/tags"
 const PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY: = PROJECT_SETTINGS_NAME_RESOURCES_TAGS + "/registry_file"
 const PROJECT_SETTINGS_NAME_RESOURCES_TAGS_GENERATED_SCRIPT: = PROJECT_SETTINGS_NAME_RESOURCES_TAGS + "/generated_script"
-
-const PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE: = true
-const PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON: = "gas_tag,gas_tags"
-const PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE: = EditorTagsTagEditorPropertyMatchType.SUFFIX
 
 const PROJECT_SETTINGS_DEFAULT_PATH: = "res://godot_gas"
 const PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE: = PROJECT_SETTINGS_DEFAULT_PATH + "/attributes_draft.cfg"
@@ -41,7 +31,6 @@ static func init_project_settings() -> void:
 	_init_project_settings_generated_tag_script_path()
 	_init_project_settings_registry_cue()
 	_init_project_settings_registry_tag()
-	_init_project_settings_editor_tag_property_editor()
 
 
 static func get_attributes_draft_config_path() -> String:
@@ -72,25 +61,6 @@ static func get_registry_tag_path() -> String:
 	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY):
 		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_TAGS_REGISTRY)
 	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY)
-
-
-static func get_editor_tag_property_editor_enabled() -> bool:
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
-	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
-
-
-static func get_editor_tag_property_editor_match_on() -> PackedStringArray:
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON)
-	var match_on_list: = ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON) as String
-	return match_on_list.split(",", false)
-
-
-static func get_editor_tag_property_editor_match_type() -> EditorTagsTagEditorPropertyMatchType:
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
-	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
 
 
 static func _init_project_settings_attributes_output_dir() -> void:
@@ -171,34 +141,6 @@ static func _init_project_settings_registry_tag() -> void:
 
 		DirAccess.make_dir_recursive_absolute(registry_path.get_base_dir())
 		ResourceSaver.save(default_registry, registry_path)
-
-
-static func _init_project_settings_editor_tag_property_editor() -> void:
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON)
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
-
-	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
-	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON)
-	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
-
-	ProjectSettings.add_property_info({
-		"name": PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE,
-		"type": TYPE_BOOL,
-	})
-	ProjectSettings.add_property_info({
-		"name": PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON,
-		"type": TYPE_STRING,
-	})
-	ProjectSettings.add_property_info({
-		"name": PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE,
-		"type": TYPE_INT,
-		"hint": PROPERTY_HINT_ENUM,
-		"hint_string": "Prefix,Suffix,Anywhere",
-	})
 
 
 ## Dynamically parses an SVG file in memory, replacing pure white/grey with the native Editor color.


### PR DESCRIPTION
>[!WARNING]
>This PR is not compatible with #12.

- Removes existing project settings that were used to detect tags.
- Makes instead use of hint strings to declare that an export needs the tag editor.