### PR TITLE
Add support for strict tags

### DIFF
--- a/GodotGAS/abilities/gameplay_ability.gd
+++ b/GodotGAS/abilities/gameplay_ability.gd
@@ -69,7 +69,7 @@ func _ready() -> void:
 
 #region Execution & State
 ## The public entry point. Accepts an optional payload if triggered by an event.
-func try_activate(event_payload: GameplayEffectContext = null) -> bool:
+func try_activate(event_payload: Variant = null) -> bool:
 	if is_active or not owner_asc:
 		return false
 	

--- a/GodotGAS/abilities/gameplay_ability.gd
+++ b/GodotGAS/abilities/gameplay_ability.gd
@@ -19,7 +19,7 @@ signal ability_ended(was_cancelled: bool)
 ## The simple name to be used for logging or UI
 @export var ability_name: String = ""
 ## The tag that uniquely identifies this ability.
-@export_custom(PROPERTY_HINT_NONE, "gas::tag") var ability_tag: StringName = "Ability.None"
+@export_custom(PROPERTY_HINT_NONE, "gas::tag,strict_only") var ability_tag: StringName = "\"Ability.None\""
 ## The current level of this ability, used for scaling math and effects.
 @export var ability_level: float = 1.0
 ## Tags that, if present on the ASC, will prevent this ability from activating.
@@ -39,7 +39,7 @@ signal ability_ended(was_cancelled: bool)
 
 @export_category("Ability Triggers")
 ## If set, the ASC will automatically try to activate this ability when it receives this exact event tag.
-@export_custom(PROPERTY_HINT_NONE, "gas::tag") var trigger_event_tag: StringName = ""
+@export_custom(PROPERTY_HINT_NONE, "gas::tag,strict_only") var trigger_event_tag: StringName = ""
 
 @export_category("Input Routing")
 ## The integer ID this ability is currently bound to. -1 means unbound.

--- a/GodotGAS/abilities/gameplay_ability.gd
+++ b/GodotGAS/abilities/gameplay_ability.gd
@@ -19,13 +19,13 @@ signal ability_ended(was_cancelled: bool)
 ## The simple name to be used for logging or UI
 @export var ability_name: String = ""
 ## The tag that uniquely identifies this ability.
-@export var ability_tag: StringName = "Ability.None"
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var ability_tag: StringName = "Ability.None"
 ## The current level of this ability, used for scaling math and effects.
 @export var ability_level: float = 1.0
 ## Tags that, if present on the ASC, will prevent this ability from activating.
-@export var activation_blocked_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var activation_blocked_tags: Array[StringName] = []
 ## Tags that, if not present on the ASC, will prevent this ability from activating.
-@export var activation_required_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var activation_required_tags: Array[StringName] = []
 
 @export_category("Ability Mechanics")
 ## The gameplay effect applied to the owner to deduct resources upon committing.
@@ -35,11 +35,11 @@ signal ability_ended(was_cancelled: bool)
 ## Any additional shared effects (like a Global Cooldown) that should be applied when cast.
 @export var shared_cooldown_effects: Array[GameplayEffect] = []
 ## Explicitly list any shared cooldowns (like GCDs) this ability should respect.
-@export var shared_cooldown_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var shared_cooldown_tags: Array[StringName] = []
 
 @export_category("Ability Triggers")
 ## If set, the ASC will automatically try to activate this ability when it receives this exact event tag.
-@export var trigger_event_tag: StringName = ""
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var trigger_event_tag: StringName = ""
 
 @export_category("Input Routing")
 ## The integer ID this ability is currently bound to. -1 means unbound.

--- a/GodotGAS/components/ability_system_component.gd
+++ b/GodotGAS/components/ability_system_component.gd
@@ -44,6 +44,8 @@ signal ability_activation_failed(ability: GameplayAbility, reason: ActivationErr
 ## UI listens to this to spawn Damage Numbers, "Miss!", or "Blocked!" text.
 signal effect_received(source_asc: AbilitySystemComponent, spec: GameplayEffectSpec)
 
+const GodotGasTagUtility: = preload("res://addons/GodotGAS/utilities/tags.gd")
+
 @export var attribute_sets: Array[AttributeSet] = []
 
 ## If false, this ASC will create a unique deep copy of its attribute sets on start.
@@ -642,39 +644,35 @@ func get_tag_duration_remaining(tag: StringName) -> float:
 
 ## Checks if the ASC has the exact given tag.
 func has_tag_exact(tag: StringName) -> bool:
-	return _active_tags.has(tag)
+	var active_tags: Array[StringName] = []
+	for _active_tag in _active_tags.keys():
+		active_tags.push_back(StringName(_active_tag))
+	return GodotGasTagUtility.has_tag(active_tags, tag, true)
 
 
 ## Checks if the ASC has the given tag or any of its children.
-func has_tag(tag: StringName) -> bool:
-	if _active_tags.has(tag):
-		return true
-		
-	var tag_str = String(tag)
-	for active_tag in _active_tags.keys():
-		var active_str = String(active_tag)
-		if active_str.begins_with(tag_str + "."):
-			return true
-			
-	return false
+func has_tag(tag: StringName, exact: = false) -> bool:
+	var active_tags: Array[StringName] = []
+	for _active_tag in _active_tags.keys():
+		active_tags.push_back(StringName(_active_tag))
+	return GodotGasTagUtility.has_tag(active_tags, tag, exact)
 
 
 ## Returns true if the ASC has at least one of the tags in the array.
-func has_any_tags(tags: Array[StringName]) -> bool:
-	for t in tags:
-		if has_tag(t):
-			return true
-	return false
+func has_any_tags(tags: Array[StringName], exact: = false) -> bool:
+	var active_tags: Array[StringName] = []
+	for _active_tag in _active_tags.keys():
+		active_tags.push_back(StringName(_active_tag))
+	return GodotGasTagUtility.has_any_tags(active_tags, tags, exact)
 
 
 ## Returns true only if the ASC has every tag in the array.
-func has_all_tags(tags: Array[StringName]) -> bool:
-	if tags.is_empty():
-		return false
-	for t in tags:
-		if not has_tag(t):
-			return false
-	return true
+func has_all_tags(tags: Array[StringName], exact: = false) -> bool:
+	var active_tags: Array[StringName] = []
+	for _active_tag in _active_tags.keys():
+		active_tags.push_back(StringName(_active_tag))
+	return GodotGasTagUtility.has_all_tags(active_tags, tags, exact)
+
 #endregion
 
 

--- a/GodotGAS/components/ability_system_component.gd
+++ b/GodotGAS/components/ability_system_component.gd
@@ -44,8 +44,6 @@ signal ability_activation_failed(ability: GameplayAbility, reason: ActivationErr
 ## UI listens to this to spawn Damage Numbers, "Miss!", or "Blocked!" text.
 signal effect_received(source_asc: AbilitySystemComponent, spec: GameplayEffectSpec)
 
-const GodotGasTagUtility: = preload("res://addons/GodotGAS/utilities/tags.gd")
-
 @export var attribute_sets: Array[AttributeSet] = []
 
 ## If false, this ASC will create a unique deep copy of its attribute sets on start.
@@ -647,7 +645,7 @@ func has_tag_exact(tag: StringName) -> bool:
 	var active_tags: Array[StringName] = []
 	for _active_tag in _active_tags.keys():
 		active_tags.push_back(StringName(_active_tag))
-	return GodotGasTagUtility.has_tag(active_tags, tag, true)
+	return GameplayTagUtilities.has_tag(active_tags, tag, true)
 
 
 ## Checks if the ASC has the given tag or any of its children.
@@ -655,7 +653,7 @@ func has_tag(tag: StringName, exact: = false) -> bool:
 	var active_tags: Array[StringName] = []
 	for _active_tag in _active_tags.keys():
 		active_tags.push_back(StringName(_active_tag))
-	return GodotGasTagUtility.has_tag(active_tags, tag, exact)
+	return GameplayTagUtilities.has_tag(active_tags, tag, exact)
 
 
 ## Returns true if the ASC has at least one of the tags in the array.
@@ -663,7 +661,7 @@ func has_any_tags(tags: Array[StringName], exact: = false) -> bool:
 	var active_tags: Array[StringName] = []
 	for _active_tag in _active_tags.keys():
 		active_tags.push_back(StringName(_active_tag))
-	return GodotGasTagUtility.has_any_tags(active_tags, tags, exact)
+	return GameplayTagUtilities.has_any_tags(active_tags, tags, exact)
 
 
 ## Returns true only if the ASC has every tag in the array.
@@ -671,7 +669,7 @@ func has_all_tags(tags: Array[StringName], exact: = false) -> bool:
 	var active_tags: Array[StringName] = []
 	for _active_tag in _active_tags.keys():
 		active_tags.push_back(StringName(_active_tag))
-	return GodotGasTagUtility.has_all_tags(active_tags, tags, exact)
+	return GameplayTagUtilities.has_all_tags(active_tags, tags, exact)
 
 #endregion
 
@@ -738,10 +736,11 @@ func send_gameplay_event(event_tag: StringName, payload: Variant = null) -> void
 	for ability in _active_abilities:
 		if ability.trigger_event_tag == event_tag:
 			# The ability was listening for this! Try to activate it and pass the data.
-			if payload is GameplayEffectContext:
-				ability.try_activate(payload)
-			elif payload is GameplayEffectSpec:
+			if payload is GameplayEffectSpec:
 				ability.try_activate(payload.context)
+			else:
+				# If `payload` is `GameplayEffectContext` or else.
+				ability.try_activate(payload)
 
 
 func _notification(what: int) -> void:
@@ -785,6 +784,8 @@ func _debug_gameplay_event_received(event_tag: StringName, payload: Variant) -> 
 		
 	if instigator:
 		payload_desc = "Payload(From: [color=cyan]%s[/color])" % instigator.name
+	elif payload != null:
+		payload_desc = "Payload([color=purple]%s[/color])" % payload 
 		
 	print_rich("[color=gray]> (DEBUG)[/color] [color=cyan]<%s>[/color] signal [color=orange][gameplay_event_received][/color] %s's ASC received [color=green]'%s'[/color] event with %s" % [self.get_parent().name, self.get_parent().name, event_tag, payload_desc])
 

--- a/GodotGAS/cues/gameplay_cue_entry.gd
+++ b/GodotGAS/cues/gameplay_cue_entry.gd
@@ -13,7 +13,7 @@ class_name GameplayCueEntry extends Resource
 
 ## The gameplay tag associated with this cue. 
 ## Note: The GameplayTag inspector plugin automatically detects the variable name "tag".
-@export var tag: StringName
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var tag: StringName
 
 ## The PackedScene containing the visual or audio effects to trigger.
 @export var scene: PackedScene

--- a/GodotGAS/effects/gameplay_effect.gd
+++ b/GodotGAS/effects/gameplay_effect.gd
@@ -47,16 +47,16 @@ enum StackingPolicy {
 @export_category("Application Requirements")
 ## The target MUST have all of these tags for this effect to apply.
 ## (e.g., Must have 'Status.Burning' for an 'Explode' effect to work).
-@export var application_required_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var application_required_tags: Array[StringName] = []
 ## The target must NOT have any of these tags. If they do, the effect is blocked.
 ## (e.g., Target has 'Status.Immune.Poison', so block poison effects).
-@export var application_ignore_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var application_ignore_tags: Array[StringName] = []
 
 @export_category("Cue Management")
 ## Cues that play exactly once when the effect is first applied to a target.
-@export var application_cue_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var application_cue_tags: Array[StringName] = []
 ## Cues that play every time a periodic tick occurs.
-@export var periodic_cue_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var periodic_cue_tags: Array[StringName] = []
 
 @export_category("Attribute Modifiers")
 ## Custom mathematical scripts that run complex logic (e.g., Damage = Attack - Defense).
@@ -68,9 +68,9 @@ enum StackingPolicy {
 ## Tags granted to the target ASC for as long as this effect is active.
 ## Not used for events, but state ie: 'Status.Stunned'
 ## NOTE: Instant effects do not grant tags.
-@export var granted_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var granted_tags: Array[StringName] = []
 
 @export_category("Event Management")
 ## Tags broadcasted directly to the target's ASC as Gameplay Events upon application (or periodic tick).
 ## Ideal for waking up reactive passive abilities (e.g., 'Event.Damage.Taken').
-@export var event_tags: Array[StringName] = []
+@export_custom(PROPERTY_HINT_NONE, "gas::tag") var event_tags: Array[StringName] = []

--- a/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd
+++ b/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd
@@ -11,8 +11,21 @@
 @icon("res://addons/GodotGAS/icons/godot_gas_asc.svg")
 extends EditorProperty
 
+enum TreeItemButtonId {
+	STRICT = 1,
+	DELETE = 2,
+}
+
 ## Addon project settings.
 const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
+## Tags utilities.
+const GodotGasTagUtility: = preload("res://addons/GodotGAS/utilities/tags.gd")
+
+## Property type.
+var property_type: = TYPE_STRING
+## Only permit selection of strict types. (tree leaves)
+var strict_only: = false
+
 
 ## The main button displayed in the inspector row.
 var _button := Button.new()
@@ -46,7 +59,17 @@ var _is_updating_from_tree: bool = false
 
 
 #region Initialization & Lifecycle
-func _init() -> void:
+func _init(property_type: = TYPE_STRING, strict_only: = false) -> void:
+	assert(
+		property_type == TYPE_ARRAY
+		or property_type == TYPE_PACKED_STRING_ARRAY
+		or property_type == TYPE_STRING
+		or property_type == TYPE_STRING_NAME,
+		"Unsupported variant property type.",
+	)
+	self.property_type = property_type
+	self.strict_only = strict_only
+
 	_registry = load(GodotGasProjectSettings.get_registry_tag_path()) as GameplayTagRegistry
 	
 	_button.text = "Edit Tags..."
@@ -107,7 +130,7 @@ func _on_registry_changed() -> void:
 			
 	# If this specific inspector row lost a tag, update its text instantly
 	if did_change:
-		_button.text = "Tags (%d selected)" % _current_tags.size()
+		_update_button_text()
 
 
 ## Synchronizes the UI with the inspected object's data.
@@ -119,10 +142,46 @@ func _update_property() -> void:
 	elif val is StringName or val is String:
 		_current_tags = [val] if not String(val).is_empty() else []
 	
-	_button.text = "Tags (%d selected)" % _current_tags.size()
+	_update_button_text()
 	
 	if is_instance_valid(_popup) and _popup.visible and not _is_updating_from_tree:
 		_refresh_tree()
+
+
+func _update_button_text() -> void:
+	var tooltip_text: = ""
+	var current_tags: = _current_tags.duplicate()
+	current_tags.sort_custom(
+		func(a: String, b: String):
+			return a.casecmp_to(b) < 0
+	)
+
+	match property_type:
+		TYPE_STRING, \
+		TYPE_STRING_NAME:
+			if current_tags.is_empty():
+				_button.text = "No tag"
+				tooltip_text = "No tag selected."
+			else:
+				_button.text = current_tags[0]
+				tooltip_text = "Selected tag:"
+				tooltip_text += "\n  - %s" % current_tags[0]
+		TYPE_ARRAY, \
+		TYPE_PACKED_STRING_ARRAY:
+			if current_tags.is_empty():
+				_button.text = "No tags"
+				tooltip_text = "No tags selected."
+			else:
+				_button.text = "Tags (%d selected)" % current_tags.size()
+				var plural: = ""
+				if current_tags.size() >= 2:
+					plural = "s"
+				tooltip_text = "Selected tag%s:" % plural
+				for current_tag in current_tags:
+					tooltip_text += "\n  - %s" % current_tag
+
+	_button.tooltip_text = tooltip_text
+
 #endregion
 
 
@@ -182,45 +241,75 @@ func _refresh_tree() -> void:
 		return
 	
 	_tree.clear()
-	var root = _tree.create_item()
-	var filter = _search_bar.text.to_lower()
+	var root: = _tree.create_item()
+	var filter: = _search_bar.text.to_lower()
 	var created_nodes: Dictionary = {}
-	var trash_icon = EditorInterface.get_editor_theme().get_icon("Remove", "EditorIcons")
+	var icon_trash: = EditorInterface.get_editor_theme().get_icon("Remove", "EditorIcons")
+	var icon_strict: = EditorInterface.get_editor_theme().get_icon("MatchCase", "EditorIcons")
+	var accent_color: Color = EditorInterface.get_editor_theme().get_color("accent_color", "Editor")
 	
 	for tag in _registry.tags:
-		var tag_str = String(tag).strip_edges()
+		var tag_str: = String(tag).strip_edges()
 		if tag_str.is_empty(): 
 			continue
-		
+
 		if not filter.is_empty() and not filter in tag_str.to_lower():
 			continue
-			
-		var parts = tag_str.split(".")
-		var current_path = ""
-		var parent_item = root
+	
+		var parts: = tag_str.split(".")
+		var current_path: = StringName()
+		var parent_item: = root
 		
 		for i in range(parts.size()):
-			var part_name = parts[i].strip_edges()
+			var part_name: = parts[i].strip_edges()
 			if part_name.is_empty(): 
 				continue
 			
-			current_path = part_name if current_path.is_empty() else current_path + "." + part_name
-			
+			current_path = StringName(
+				part_name \
+					if current_path.is_empty() \
+					else current_path + "." + part_name,
+			)
+
 			if created_nodes.has(current_path):
 				parent_item = created_nodes[current_path]
 			else:
-				var item = _tree.create_item(parent_item)
-				item.set_metadata(0, current_path)
-				
+				var item: = _tree.create_item(parent_item)
+				var item_checked: = false
+				var tag_is_strict: = strict_only
+
+				if current_path in _current_tags:
+					item_checked = true
+				elif GodotGasTagUtility.to_strict(current_path) in _current_tags:
+					item_checked = true
+					tag_is_strict = true
+
+				item.set_metadata(0, {
+					"tag": current_path,
+					"is_strict": tag_is_strict,
+				})
+				item.set_cell_mode(0, TreeItem.CELL_MODE_CHECK)
+				item.set_text(0, part_name)
+				item.set_tooltip_text(
+					0, 
+					GodotGasTagUtility.to_strict(current_path) \
+						if tag_is_strict \
+						else current_path,
+				)
+				item.set_checked(0, item_checked)
+				item.set_editable(0, true)
+
 				if current_path == tag_str:
-					item.set_cell_mode(0, TreeItem.CELL_MODE_CHECK)
-					item.set_text(0, part_name)
-					item.set_checked(0, _current_tags.has(StringName(current_path)))
-					item.set_editable(0, true)
-					item.add_button(0, trash_icon, 1, false, "Delete from Registry")
-				else:
-					item.set_text(0, part_name)
-					
+					var icon_strict_index: = 0
+
+					if not strict_only:
+						item.add_button(0, icon_strict, TreeItemButtonId.STRICT, not item_checked, "Strict Match")
+						icon_strict_index = item.get_button_count(0) - 1
+						if tag_is_strict:
+							item.set_button_color(0, icon_strict_index, accent_color)
+
+					item.add_button(0, icon_trash, TreeItemButtonId.DELETE, false, "Delete from Registry")
+
 				created_nodes[current_path] = item
 				parent_item = item
 
@@ -230,8 +319,13 @@ func _on_tree_item_edited() -> void:
 	if not item:
 		return
 	
-	var tag_path = StringName(item.get_metadata(0))
+	var metadata: Dictionary = item.get_metadata(0)
+	var tag: StringName = metadata["tag"]
+	var tag_is_strict: bool = metadata["is_strict"]
 	var is_checked = item.is_checked(0)
+
+	if tag_is_strict:
+		tag = GodotGasTagUtility.to_strict(tag)
 	
 	_is_updating_from_tree = true
 	
@@ -245,17 +339,17 @@ func _on_tree_item_edited() -> void:
 			new_typed_array.assign(prop_val)
 			
 		# 3. Apply the changes
-		if is_checked and not new_typed_array.has(tag_path):
-			new_typed_array.append(tag_path)
-		elif not is_checked and new_typed_array.has(tag_path):
-			new_typed_array.erase(tag_path)
+		if is_checked and not new_typed_array.has(tag):
+			new_typed_array.append(tag)
+		elif not is_checked and new_typed_array.has(tag):
+			new_typed_array.erase(tag)
 			
 		# 4. Sync UI tracking and emit the perfectly typed data
 		_current_tags = Array(new_typed_array)
 		emit_changed(get_edited_property(), new_typed_array if prop_val is Array else PackedStringArray(new_typed_array))
 	else:
 		if is_checked:
-			emit_changed(get_edited_property(), tag_path)
+			emit_changed(get_edited_property(), tag)
 		else:
 			emit_changed(get_edited_property(), StringName(""))
 			
@@ -267,10 +361,28 @@ func _on_tree_item_edited() -> void:
 
 
 func _on_tree_button_clicked(item: TreeItem, column: int, id: int, mouse_button_index: int) -> void:
-	if id != 1:
-		return
+	match id:
+		TreeItemButtonId.STRICT:
+			_on_tree_button_strict(item, column, id, mouse_button_index)
+		TreeItemButtonId.DELETE:
+			_on_tree_button_delete(item, column, id, mouse_button_index)
 
-	var tag_to_remove = StringName(item.get_metadata(0))
+
+func _on_tree_button_strict(item: TreeItem, column: int, _id: int, mouse_button_index: int) -> void:
+	var metadata: Dictionary = item.get_metadata(0)
+	var tag: StringName = metadata["tag"]
+	var tag_is_strict: bool = metadata["is_strict"]
+	var old_tag: = tag
+	var new_tag: = tag
+	var old_tag_is_strict: = tag_is_strict
+	# The intent by clicking is to switch the current value.
+	var new_tag_is_strict: = not tag_is_strict  
+
+	if old_tag_is_strict:
+		old_tag = GodotGasTagUtility.to_strict(tag)
+	if new_tag_is_strict:
+		new_tag = GodotGasTagUtility.to_strict(tag)
+
 	var prop_val = get_edited_object().get(get_edited_property())
 	var is_array_type = prop_val is Array or prop_val is PackedStringArray
 	
@@ -279,21 +391,52 @@ func _on_tree_button_clicked(item: TreeItem, column: int, id: int, mouse_button_
 		var new_typed_array: Array[StringName] = []
 		if prop_val != null:
 			new_typed_array.assign(prop_val)
+
+		var tag_index: = new_typed_array.find(old_tag)
+		if tag_index > -1:
+			new_typed_array.set(tag_index, new_tag)
+
+		_current_tags = Array(new_typed_array)
+		emit_changed(get_edited_property(), new_typed_array if prop_val is Array else PackedStringArray(new_typed_array))
+		
+	elif not is_array_type and _current_tags.size() > 0 and _current_tags[0] == old_tag:
+		_current_tags.set(0, new_tag)
+		emit_changed(get_edited_property(), StringName(new_tag))
+	
+	_update_button_text()
+	_refresh_tree()
+
+
+func _on_tree_button_delete(item: TreeItem, column: int, _id: int, mouse_button_index: int) -> void:
+	var metadata: Dictionary = item.get_metadata(0)
+	var tag: StringName = metadata["tag"]
+	var tag_is_strict: bool = metadata["is_strict"]
+	var prop_val = get_edited_object().get(get_edited_property())
+	var is_array_type = prop_val is Array or prop_val is PackedStringArray
+
+	if tag_is_strict:
+		tag = GodotGasTagUtility.to_strict(tag)
+
+	if is_array_type:
+		# Break memory link with strictly typed array
+		var new_typed_array: Array[StringName] = []
+		if prop_val != null:
+			new_typed_array.assign(prop_val)
 			
-		if new_typed_array.has(tag_to_remove):
-			new_typed_array.erase(tag_to_remove)
+		if new_typed_array.has(tag):
+			new_typed_array.erase(tag)
 			
 		_current_tags = Array(new_typed_array)
 		emit_changed(get_edited_property(), new_typed_array if prop_val is Array else PackedStringArray(new_typed_array))
 		
-	elif not is_array_type and _current_tags.size() > 0 and _current_tags[0] == tag_to_remove:
+	elif not is_array_type and _current_tags.size() > 0 and _current_tags[0] == tag:
 		_current_tags.clear()
 		emit_changed(get_edited_property(), StringName(""))
 	
-	_button.text = "Tags (%d selected)" % _current_tags.size()
+	_update_button_text()
 	
-	_registry.remove_tag(tag_to_remove)
-	_set_status("Deleted tag: " + tag_to_remove, true)
+	_registry.remove_tag(tag)
+	_set_status("Deleted tag: " + tag, true)
 	_refresh_tree()
 
 

--- a/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd
+++ b/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd
@@ -18,8 +18,6 @@ enum TreeItemButtonId {
 
 ## Addon project settings.
 const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
-## Tags utilities.
-const GodotGasTagUtility: = preload("res://addons/GodotGAS/utilities/tags.gd")
 
 ## Property type.
 var property_type: = TYPE_STRING
@@ -280,7 +278,7 @@ func _refresh_tree() -> void:
 
 				if current_path in _current_tags:
 					item_checked = true
-				elif GodotGasTagUtility.to_strict(current_path) in _current_tags:
+				elif GameplayTagUtilities.to_strict(current_path) in _current_tags:
 					item_checked = true
 					tag_is_strict = true
 
@@ -292,7 +290,7 @@ func _refresh_tree() -> void:
 				item.set_text(0, part_name)
 				item.set_tooltip_text(
 					0, 
-					GodotGasTagUtility.to_strict(current_path) \
+					GameplayTagUtilities.to_strict(current_path) \
 						if tag_is_strict \
 						else current_path,
 				)
@@ -325,7 +323,7 @@ func _on_tree_item_edited() -> void:
 	var is_checked = item.is_checked(0)
 
 	if tag_is_strict:
-		tag = GodotGasTagUtility.to_strict(tag)
+		tag = GameplayTagUtilities.to_strict(tag)
 	
 	_is_updating_from_tree = true
 	
@@ -379,9 +377,9 @@ func _on_tree_button_strict(item: TreeItem, column: int, _id: int, mouse_button_
 	var new_tag_is_strict: = not tag_is_strict  
 
 	if old_tag_is_strict:
-		old_tag = GodotGasTagUtility.to_strict(tag)
+		old_tag = GameplayTagUtilities.to_strict(tag)
 	if new_tag_is_strict:
-		new_tag = GodotGasTagUtility.to_strict(tag)
+		new_tag = GameplayTagUtilities.to_strict(tag)
 
 	var prop_val = get_edited_object().get(get_edited_property())
 	var is_array_type = prop_val is Array or prop_val is PackedStringArray
@@ -415,7 +413,7 @@ func _on_tree_button_delete(item: TreeItem, column: int, _id: int, mouse_button_
 	var is_array_type = prop_val is Array or prop_val is PackedStringArray
 
 	if tag_is_strict:
-		tag = GodotGasTagUtility.to_strict(tag)
+		tag = GameplayTagUtilities.to_strict(tag)
 
 	if is_array_type:
 		# Break memory link with strictly typed array

--- a/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd
+++ b/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd
@@ -14,9 +14,9 @@ extends EditorInspectorPlugin
 ## The preloaded custom editor property script used for tag selection.
 const GameplayTagEditorProperty = preload("res://addons/GodotGAS/gameplay_tag/gameplay_tag_editor_property.gd")
 
-## Addon project settings.
-const GodotGasProjectSettings: = preload("res://addons/GodotGAS/utilities/project_settings.gd")
-
+const HINT_STRING_DELIMITER: = ","
+const HINT_STRING_GAS_PREFIX: = "gas::"
+const HINT_STRING_GAS_TAG_PREFIX: = "gas::tag"
 
 #region Inspector Parsing
 ## Native Godot virtual to determine if this plugin handles the current object.
@@ -27,30 +27,11 @@ func _can_handle(object: Object) -> bool:
 
 ## Native Godot virtual that intercepts property rendering to inject custom UI.
 func _parse_property(object: Object, type: Variant.Type, name: String, hint_type: PropertyHint, hint_string: String, usage_flags: int, wide: bool) -> bool:
-	# Here, we check if the object in the inspector is literally a `GameplayTagRegistry`.
-	var is_native: = name.to_lower() == "tags" and object is GameplayTagRegistry
-	if not GodotGasProjectSettings.get_editor_tag_property_editor_enabled() or is_native:
-		# Make sure to return `false` when `is native` because we don't want the tag editor property
-		# to show up in the registries. People could start to click on tags to deactivate them,
-		# but it would instead delete them permanently.
+	if hint_type != PROPERTY_HINT_NONE:
 		return false
-	var matches_on: = GodotGasProjectSettings.get_editor_tag_property_editor_match_on()
-	var match_type: = GodotGasProjectSettings.get_editor_tag_property_editor_match_type()
 
-	# We intercept arrays or strings containing the needle.
-	# Here, we match 
-	var matched: = false
-	if not matched:
-		for match_on in matches_on:
-			match match_type:
-				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.PREFIX:
-					matched = name.to_lower().begins_with(match_on)
-				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.SUFFIX:
-					matched = name.to_lower().ends_with(match_on)
-				GodotGasProjectSettings.EditorTagsTagEditorPropertyMatchType.ANYWHERE:
-					matched = match_on in name.to_lower()
-			if matched:
-				break
+	var hint_string_args: = hint_string.split(HINT_STRING_DELIMITER)
+	var matched: = HINT_STRING_GAS_TAG_PREFIX in hint_string_args
 
 	if matched:
 		match type:

--- a/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd
+++ b/GodotGAS/gameplay_tag/gameplay_tag_inspector_plugin.gd
@@ -17,6 +17,7 @@ const GameplayTagEditorProperty = preload("res://addons/GodotGAS/gameplay_tag/ga
 const HINT_STRING_DELIMITER: = ","
 const HINT_STRING_GAS_PREFIX: = "gas::"
 const HINT_STRING_GAS_TAG_PREFIX: = "gas::tag"
+const HINT_STRING_GAS_TAG_HINT_STRICT_ONLY: = "strict_only"
 
 #region Inspector Parsing
 ## Native Godot virtual to determine if this plugin handles the current object.
@@ -32,6 +33,7 @@ func _parse_property(object: Object, type: Variant.Type, name: String, hint_type
 
 	var hint_string_args: = hint_string.split(HINT_STRING_DELIMITER)
 	var matched: = HINT_STRING_GAS_TAG_PREFIX in hint_string_args
+	var strict_only: = HINT_STRING_GAS_TAG_HINT_STRICT_ONLY in hint_string_args
 
 	if matched:
 		match type:
@@ -39,7 +41,7 @@ func _parse_property(object: Object, type: Variant.Type, name: String, hint_type
 			TYPE_PACKED_STRING_ARRAY, \
 			TYPE_STRING, \
 			TYPE_STRING_NAME:
-				var editor_property = GameplayTagEditorProperty.new()
+				var editor_property = GameplayTagEditorProperty.new(type, strict_only)
 				add_property_editor(name, editor_property)
 				return true # Tells Godot to skip rendering the default input field
 			

--- a/GodotGAS/utilities/project_settings.gd
+++ b/GodotGAS/utilities/project_settings.gd
@@ -7,12 +7,6 @@ enum EditorTagsTagEditorPropertyMatchType {
 }
 
 const PROJECT_SETTINGS_NAME: = "godot_gas"
-const PROJECT_SETTINGS_NAME_EDITOR: = PROJECT_SETTINGS_NAME + "/editor"
-const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR: = PROJECT_SETTINGS_NAME_EDITOR + "/tag_property_editor"
-const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR + "/enable"
-const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR + "/match"
-const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH + "/on"
-const PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE: = PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH + "/type"
 const PROJECT_SETTINGS_NAME_RESOURCES: = PROJECT_SETTINGS_NAME + "/resources"
 const PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES: = PROJECT_SETTINGS_NAME_RESOURCES + "/attributes"
 const PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE: = PROJECT_SETTINGS_NAME_RESOURCES_ATTRIBUTES + "/draft_configuration_file"
@@ -22,10 +16,6 @@ const PROJECT_SETTINGS_NAME_RESOURCES_CUES_REGISTRY: = PROJECT_SETTINGS_NAME_RES
 const PROJECT_SETTINGS_NAME_RESOURCES_TAGS: = PROJECT_SETTINGS_NAME_RESOURCES + "/tags"
 const PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY: = PROJECT_SETTINGS_NAME_RESOURCES_TAGS + "/registry_file"
 const PROJECT_SETTINGS_NAME_RESOURCES_TAGS_GENERATED_SCRIPT: = PROJECT_SETTINGS_NAME_RESOURCES_TAGS + "/generated_script"
-
-const PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE: = true
-const PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON: = "gas_tag,gas_tags"
-const PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE: = EditorTagsTagEditorPropertyMatchType.SUFFIX
 
 const PROJECT_SETTINGS_DEFAULT_PATH: = "res://godot_gas"
 const PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_ATTRIBUTES_DRAFT_CONFIG_FILE: = PROJECT_SETTINGS_DEFAULT_PATH + "/attributes_draft.cfg"
@@ -41,7 +31,6 @@ static func init_project_settings() -> void:
 	_init_project_settings_generated_tag_script_path()
 	_init_project_settings_registry_cue()
 	_init_project_settings_registry_tag()
-	_init_project_settings_editor_tag_property_editor()
 
 
 static func get_attributes_draft_config_path() -> String:
@@ -72,25 +61,6 @@ static func get_registry_tag_path() -> String:
 	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY):
 		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY, PROJECT_SETTINGS_DEFAULT_PATH_RESOURCES_TAGS_REGISTRY)
 	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_RESOURCES_TAGS_REGISTRY)
-
-
-static func get_editor_tag_property_editor_enabled() -> bool:
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
-	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
-
-
-static func get_editor_tag_property_editor_match_on() -> PackedStringArray:
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON)
-	var match_on_list: = ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON) as String
-	return match_on_list.split(",", false)
-
-
-static func get_editor_tag_property_editor_match_type() -> EditorTagsTagEditorPropertyMatchType:
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
-	return ProjectSettings.get_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
 
 
 static func _init_project_settings_attributes_output_dir() -> void:
@@ -171,34 +141,6 @@ static func _init_project_settings_registry_tag() -> void:
 
 		DirAccess.make_dir_recursive_absolute(registry_path.get_base_dir())
 		ResourceSaver.save(default_registry, registry_path)
-
-
-static func _init_project_settings_editor_tag_property_editor() -> void:
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON)
-	if not ProjectSettings.has_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE):
-		ProjectSettings.set_setting(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
-
-	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_ENABLE)
-	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON)
-	ProjectSettings.set_initial_value(PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE, PROJECT_SETTINGS_DEFAULT_VALUE_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE)
-
-	ProjectSettings.add_property_info({
-		"name": PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_ENABLE,
-		"type": TYPE_BOOL,
-	})
-	ProjectSettings.add_property_info({
-		"name": PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_ON,
-		"type": TYPE_STRING,
-	})
-	ProjectSettings.add_property_info({
-		"name": PROJECT_SETTINGS_NAME_EDITOR_TAG_PROPERTY_EDITOR_MATCH_TYPE,
-		"type": TYPE_INT,
-		"hint": PROPERTY_HINT_ENUM,
-		"hint_string": "Prefix,Suffix,Anywhere",
-	})
 
 
 ## Dynamically parses an SVG file in memory, replacing pure white/grey with the native Editor color.

--- a/GodotGAS/utilities/tag.gd
+++ b/GodotGAS/utilities/tag.gd
@@ -1,0 +1,68 @@
+extends Object
+
+const STR_DOUBLE_QUOTE: = "\""
+
+
+## Checks if the ASC has the given tag or any of its children.
+static func has_tag(tags: Array[StringName], tag_query: StringName, exact: = false) -> bool:
+	if tag_query in tags:
+		return true
+	if exact:
+		return false
+
+	var tag_query_str = String(tag_query)
+	for tag in tags:
+		var tag_str = String(tag)
+		if tag_str.begins_with(tag_query_str + "."):
+			return true
+
+	return false
+
+
+## Returns true if the ASC has at least one of the tags in the array.
+static func has_any_tags(tags: Array[StringName], tag_queries: Array[StringName], exact: = false) -> bool:
+	for tag_query in tag_queries:
+		if has_tag(tags, tag_query, exact):
+			return true
+	return false
+
+
+## Returns true only if the ASC has every tag in the array.
+static func has_all_tags(tags: Array[StringName], tag_queries: Array[StringName], exact: = false) -> bool:
+	if tag_queries.is_empty():
+		return false
+	for tag_query in tag_queries:
+		if not has_tag(tags, tag_query, exact):
+			return false
+	return true
+
+
+## Returns if the supplied tag is considered "strict".
+static func is_strict(tag_query: StringName) -> bool:
+	return \
+		tag_query.begins_with(STR_DOUBLE_QUOTE) \
+		and tag_query.ends_with(STR_DOUBLE_QUOTE)
+
+
+## Returns a strict representation of the tag.
+static func to_strict(tag_query: StringName) -> StringName:
+	if is_strict(tag_query):
+		return tag_query
+	var test: = StringName(
+		STR_DOUBLE_QUOTE \
+		+ tag_query \
+		+ STR_DOUBLE_QUOTE
+	)
+	return test
+
+
+## Returns a strict representation of the tag.
+static func to_lax(tag_query: StringName) -> StringName:
+	if not is_strict(tag_query):
+		return tag_query
+	return StringName(
+		tag_query \
+			.trim_prefix(STR_DOUBLE_QUOTE) \
+			.trim_suffix(STR_DOUBLE_QUOTE)
+	)
+

--- a/GodotGAS/utilities/tag.gd
+++ b/GodotGAS/utilities/tag.gd
@@ -1,4 +1,5 @@
 extends Object
+class_name GameplayTagUtilities
 
 const STR_DOUBLE_QUOTE: = "\""
 
@@ -65,4 +66,8 @@ static func to_lax(tag_query: StringName) -> StringName:
 			.trim_prefix(STR_DOUBLE_QUOTE) \
 			.trim_suffix(STR_DOUBLE_QUOTE)
 	)
+
+
+static func is_equal(a: StringName, b: StringName) -> bool:
+    return to_lax(a) == to_lax(b)
 

--- a/GodotGAS/utilities/tag.gd.uid
+++ b/GodotGAS/utilities/tag.gd.uid
@@ -1,0 +1,1 @@
+uid://dgf8rwo724h2g


### PR DESCRIPTION
Supersedes #13

This PR implements #13 and add support for strict tags on top of it. Incidentally, by supporting "strict tags", it makes it possible to enable non-strict tags (i.e. parents) in the tag property editor.

<img width="521" height="493" alt="Capture d’écran, le 2026-08-08 à 18 57 33" src="https://github.com/user-attachments/assets/ca559fb4-86b4-41f3-a676-8b01d68617c6" />

This PR also adds a new hint, `strict_only`:
```gdscript
@export_custom(PROPERTY_HINT_NONE, "gas::tag,strict_only") var ability_tag: StringName = "\"Ability.None\""
```
With `strict_only`, it is possible to ensure that the selected tags are strict, i.e. tree leaves.
